### PR TITLE
Link to announcement of 0.0.3 on r2dii

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -32,8 +32,18 @@ navbar:
     - icon: fa-github
       href: https://github.com/2DegreesInvesting/r2dii.data/
 
-    - text: r2dii
-      href: https://2degreesinvesting.github.io/r2dii/index.html
+  left:
+  - text: "Reference"
+    href: reference/index.html
+
+  - text: "News"
+    menu:
+    - text: "Release notes"
+    - text: "r2dii.data 0.0.3"
+      href: https://2degreesinvesting.github.io/r2dii/articles/r2dii-data-0-0-3.html
+    - text: "----------------------"
+    - text: "Change log"
+      href: news/index.html
 
 reference:
 


### PR DESCRIPTION
This adds  a menu under the News tab on the package website, pointing to the Changelog and also to release notes announced in r2dii. Instpired by rlang.