### PR TITLE
Fix formatting

### DIFF
--- a/R/scenario_demo_2020.R
+++ b/R/scenario_demo_2020.R
@@ -21,8 +21,8 @@
 #' in 2020.
 #' * `technology` (character): The technology within the sector to which the
 #' scenario prescribes a pathway.
-#' * `tmsr` (double): Technology market share ratio of the pathway calculated in
-#' 2020.
+#' * `tmsr` (double): Technology market share ratio of the pathway calculated
+#' in 2020.
 #' * `year` (integer): The year at which the pathway value is prescribed.
 #'
 #' @examples

--- a/man/scenario_demo_2020.Rd
+++ b/man/scenario_demo_2020.Rd
@@ -15,12 +15,8 @@ pathway.
 in 2020.
 \item \code{technology} (character): The technology within the sector to which the
 scenario prescribes a pathway.
-\item \code{tmsr} (double): Technology market share ratio of the pathway calculated in
-}
-\enumerate{
-\item 
-}
-\itemize{
+\item \code{tmsr} (double): Technology market share ratio of the pathway calculated
+in 2020.
 \item \code{year} (integer): The year at which the pathway value is prescribed.
 }
 }


### PR DESCRIPTION
I suspect a bug in roxygen. If the line breakes so that 2020 is
in a new line, then 2020 renders as 1. If the line breaks so
the new line as "in 2020" then it renders correctly.