### PR TITLE
Expose one non-ascii characters in loanbook_demo

### DIFF
--- a/tests/testthat/test-loanbook_demo.R
+++ b/tests/testthat/test-loanbook_demo.R
@@ -9,3 +9,9 @@ test_that("is not different compared to reference", {
   reference <- readRDS(test_path("ref-loanbook_demo"))
   expect_identical(loanbook_demo, reference)
 })
+
+test_that("has all ascii characters", {
+  x <- r2dii.data::loanbook_demo$name_direct_loantaker
+  is_ascii <- stringr::str_detect(stringi::stri_enc_mark(x), "ASCII")
+  expect_true(all(is_ascii))
+})


### PR DESCRIPTION
There are a number of non-ascii characters that rise a NOTE
on CRAN results. This is not obvious during pre-release checks
but appraers in CRAN results. It seems wise to fix this problem
and leave a test that ensures this does not happen again in new
datasets.
