### PR TITLE
move source data raw

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -95,11 +95,14 @@ jobs:
           install.packages('dplyr')
           install.packages('usethis')
           install.packages('here')
+          install.packages('remotes')
+          remotes::install_github('2DegreesInvesting/r2dii.usethis')
+
         shell: Rscript {0}
       - name: Update data-raw step 3 - Source R files in data-raw
         run: |
           source(file.path('R', 'utils.R'))
-          source_data_raw()
+          r2dii.usethis::source_data_raw()
         shell: Rscript {0}
 
       - name: Check

--- a/R/classification_bridge.R
+++ b/R/classification_bridge.R
@@ -109,4 +109,4 @@
 #'
 #' @examples
 #' head(psic_classification)
-'psic_classification'
+"psic_classification"

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,29 +1,3 @@
-#' Source all .R files under data-raw/
-#'
-#' Usually we work on one dataset only, and don't know if our change impacted
-#' other datasets. This function helps "refresh" all datasets at once. It may
-#' be used interactively while developing the package, or in CI to regularly
-#' check we can reproduce all datasets we export, and that the result is
-#' consistent with our regression tests.
-#'
-#' @return `invisible()`, as it's called for its side effect.
-#' @keywords internal
-#'
-#' @examples
-#' source_data_raw()
-#' @noRd
-source_data_raw <- function(path = "data-raw") {
-  lapply(r_files_in(path), source)
-
-  invisible(path)
-}
-
-r_files_in <- function(path) {
-  # pattern = "[.]R$" is simpler but platform-inconsistent, e.g. "a//b", "a/b".
-  path_ext <- list.files(path, pattern = NULL, full.names = TRUE)
-  grep("[.]R$", path_ext, value = TRUE)
-}
-
 #' Create a list of all or some datasets exported by a package
 #'
 #' @param package A character string of length-1 giving the name of a package.

--- a/data-raw/region_isos.R
+++ b/data-raw/region_isos.R
@@ -95,7 +95,7 @@ exclude_values <- function(data, values, .region) {
 # actual isos from a real ALD file, and buffer the potentially missing isos.
 ald_isos <- read_regions(
   file.path("data-raw", paste0("ald_all_isos", ".csv"))
-  )
+)
 
 ald_isos_weo_2019 <- mutate(ald_isos, source = "weo_2019")
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,24 +1,3 @@
-test_that("source_data_raw() sources .R files and only .R files", {
-  data_raw <- file.path(tempdir(), "data-raw")
-  if (!dir.exists(data_raw)) {
-    dir.create(data_raw)
-  }
-
-  on.exit(unlink(data_raw, recursive = TRUE), add = TRUE)
-
-  test_r <- file.path(data_raw, "test.R")
-  writeLines("r_test <- 'should exist'", test_r)
-  on.exit(unlink(test_r), add = TRUE)
-
-  test_txt <- file.path(data_raw, "test.txt")
-  writeLines("txt_test <- 'should not exist'", test_txt)
-  on.exit(unlink(test_txt), add = TRUE)
-
-  source_data_raw(data_raw)
-  expect_true(exists("r_test"))
-  expect_false(exists("txt_test"))
-})
-
 test_that("define() produces the expected output", {
   expected <- c(
     "* `isos` (character): Countries in region, defined by iso code.",


### PR DESCRIPTION
This is a safe PR that touches no production code except for style. The main goal is to
move `source_data_raw()` out from here and to r2dii.usethis. There it'll be more
discoverable/reusable, and it leaves this repo more focused.