### PR TITLE
README now gives simpler installation instructions

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -33,12 +33,7 @@ PACTA in R.
 
 ## Installation
 
-Before you install r2dii.analysis you may want to:
-
-* [Try an rstudio.cloud project with this package already installed](https://rstudio.cloud/project/1424833).
-* [Learn how to minimize installation errors](https://gist.github.com/maurolepore/a0187be9d40aee95a43f20a85f4caed6#installation).
-
-When you are ready, install the released version of r2dii.data from CRAN with:
+Install the released version of r2dii.data from CRAN with:
 
 ```r
 install.packages("r2dii.data")

--- a/README.md
+++ b/README.md
@@ -27,15 +27,7 @@ development and use of PACTA in R.
 
 ## Installation
 
-Before you install r2dii.analysis you may want to:
-
--   [Try an rstudio.cloud project with this package already
-    installed](https://rstudio.cloud/project/1424833).
--   [Learn how to minimize installation
-    errors](https://gist.github.com/maurolepore/a0187be9d40aee95a43f20a85f4caed6#installation).
-
-When you are ready, install the released version of r2dii.data from CRAN
-with:
+Install the released version of r2dii.data from CRAN with:
 
 ``` r
 install.packages("r2dii.data")


### PR DESCRIPTION
I now think that maintaining an RStudio cloud project with r2dii
packages installed is a bad idea because we haven't been updating
that project. I rather not nudge users to try an R environment with
outdated r2dii packages.
