### PR TITLE
Fix workflow name

### DIFF
--- a/.github/workflows/R-CMD-check_r2dii-devel.yaml
+++ b/.github/workflows/R-CMD-check_r2dii-devel.yaml
@@ -10,7 +10,7 @@ on:
   pull_request:
     branches: [main, master]
 
-name: R-CMD-check
+name: R-CMD-check r2dii-devel
 
 jobs:
   R-CMD-check:


### PR DESCRIPTION
This is a tiny change to ensure the name of the devel R CMD check is different from the one that runs with CRAN packages.

No review needed.